### PR TITLE
Continue Python rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,22 @@ For more instructions and references see this [temporary copy of the old wiki pa
 The L3 algorithm and software were developed by Steven Lansel and Brian Wandell at Stanford University.  The code in this repository was initially drafted by SL, edited to work with ISET by SL and BW, and then extensively developed, extended and tested by Haomiao Jiang with help from Qiyuan Tian, Steve Lansel and Brian Wandell.  To reference this software, please use the patent and paper cited at the top.
 
 
+
+## Python Port
+This repository originally contained MATLAB code.  A Python implementation has
+started under the `isetL3` package.  The port currently includes
+
+* `l3_root_path()` – helper to locate the repository root
+* Data classes (`L3DataCamera`, `L3DataSimulation`)
+* A simple classifier and ordinary least squares trainer
+* A very small renderer to apply learned kernels
+
+The code is only a minimal starting point but demonstrates the training and
+rendering workflow.  See the `example_python_usage.py` script below for a small
+example using NumPy arrays as data.
+
+```
+pip install numpy
+python example_python_usage.py
+```
+

--- a/example_python_usage.py
+++ b/example_python_usage.py
@@ -1,0 +1,28 @@
+"""Small example demonstrating the Python port."""
+
+import numpy as np
+from isetL3.classify import SimpleClassifier
+from isetL3.data import L3DataCamera
+from isetL3.train import L3TrainOLS
+from isetL3.render import L3Render
+
+
+# Create synthetic raw/target data
+raw = np.random.rand(8, 8)
+rgb = np.stack([raw, raw, raw], axis=-1)
+
+# simple CFA map
+cfa = np.array([[1, 2], [3, 4]])
+
+# Build data class
+l3d = L3DataCamera([raw], [rgb], cfa)
+
+# Classification + training
+classifier = SimpleClassifier(patch_size=5)
+trainer = L3TrainOLS(l3c=classifier)
+trainer.train(l3d)
+
+# Render
+renderer = L3Render()
+rendered = renderer.render(raw, l3d.p_type, trainer)
+print("Rendered shape:", rendered.shape)

--- a/isetL3/__init__.py
+++ b/isetL3/__init__.py
@@ -1,0 +1,7 @@
+"""Python utilities for the L3 algorithm."""
+
+from .l3rootpath import l3_root_path
+
+__all__ = [
+    "l3_root_path",
+]

--- a/isetL3/classify/__init__.py
+++ b/isetL3/classify/__init__.py
@@ -1,0 +1,6 @@
+"""Classification utilities for L3."""
+
+from .l3_classify_s import L3ClassifyS
+from .simple_classifier import SimpleClassifier
+
+__all__ = ["L3ClassifyS", "SimpleClassifier"]

--- a/isetL3/classify/l3_classify_s.py
+++ b/isetL3/classify/l3_classify_s.py
@@ -1,0 +1,36 @@
+from abc import ABC, abstractmethod
+from typing import Any, Tuple
+
+
+class L3ClassifyS(ABC):
+    """Abstract base class for L3 data classification."""
+
+    def __init__(
+        self,
+        name: str = "",
+        patch_size: int = 0,
+        p_max: int = 0,
+    ) -> None:
+        self.name = name
+        self.patch_size = patch_size
+        self.p_max = p_max
+
+    @abstractmethod
+    def classify(self, *args: Any, **kwargs: Any) -> Any:
+        """Return labels for input data."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear_data(self, *args: Any, **kwargs: Any) -> None:
+        """Clear intermediate statistics and computed labels."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_class_data(
+        self,
+        label: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Tuple[Any, Any]:
+        """Return patches for a class and their locations."""
+        raise NotImplementedError

--- a/isetL3/classify/simple_classifier.py
+++ b/isetL3/classify/simple_classifier.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Tuple, List
+
+import numpy as np
+
+from .l3_classify_s import L3ClassifyS
+
+
+class SimpleClassifier(L3ClassifyS):
+    """Simplified classifier splitting patches by pixel type."""
+
+    def __init__(self, patch_size: int = 5, p_max: int = 1000) -> None:
+        super().__init__(name="simple", patch_size=patch_size, p_max=p_max)
+        self.labels: List[np.ndarray] | None = None
+        self.store_data = True
+        self.p_data: List[np.ndarray] | None = None
+        self.p_out: List[np.ndarray] | None = None
+
+    @property
+    def n_labels(self) -> int:
+        if self.labels is None:
+            return 0
+        vals = [np.max(arr) for arr in self.labels]
+        return int(np.max(vals) + 1)
+
+    def classify(
+        self, l3d: Any, *args: Any, **kwargs: Any
+    ) -> List[np.ndarray]:
+        raw_list, out_list, p_type = l3d.data_get(len(l3d.in_img))
+        self.labels = []
+        self.p_data = []
+        self.p_out = []
+        for raw, out in zip(raw_list, out_list):
+            labels = p_type.copy()
+            self.labels.append(labels)
+            if self.store_data:
+                self.p_data.append(raw.reshape(-1, 1))
+                shaped = out.reshape(-1, out.shape[-1])
+                self.p_out.append(shaped)
+        return self.labels
+
+    def clear_data(self, *args: Any, **kwargs: Any) -> None:
+        self.p_data = None
+        self.p_out = None
+        self.labels = None
+
+    def get_class_data(
+        self, label: Any, *args: Any, **kwargs: Any
+    ) -> Tuple[Any, Any]:
+        if self.labels is None or self.p_data is None:
+            return None, None
+        all_data = []
+        all_out = []
+        for lbl, data, out in zip(self.labels, self.p_data, self.p_out):
+            mask = lbl.reshape(-1) == label
+            all_data.append(data[mask])
+            all_out.append(out[mask])
+        return np.vstack(all_data), np.vstack(all_out)

--- a/isetL3/data/__init__.py
+++ b/isetL3/data/__init__.py
@@ -1,0 +1,7 @@
+"""Data generation utilities for L3."""
+
+from .l3_data_s import L3DataS
+from .l3_data_camera import L3DataCamera
+from .l3_data_simulation import L3DataSimulation
+
+__all__ = ["L3DataS", "L3DataCamera", "L3DataSimulation"]

--- a/isetL3/data/l3_data_camera.py
+++ b/isetL3/data/l3_data_camera.py
@@ -1,0 +1,28 @@
+from typing import List, Any, Tuple
+
+from .l3_data_s import L3DataS
+
+
+class L3DataCamera(L3DataS):
+    """Camera data stored in memory."""
+
+    def __init__(
+        self,
+        in_img: List[Any],
+        out_img: List[Any],
+        cfa: Any,
+        name: str = "l3 Camera Data Class Instance",
+    ) -> None:
+        super().__init__(name)
+        self.in_img = list(in_img)
+        self.out_img = list(out_img)
+        self._cfa = cfa
+
+    @property
+    def cfa(self) -> Any:
+        return self._cfa
+
+    def data_get(
+        self, n_img: int = 1, *args: Any, **kwargs: Any
+    ) -> Tuple[List[Any], List[Any], Any]:
+        return self.in_img[:n_img], self.out_img[:n_img], self.p_type

--- a/isetL3/data/l3_data_s.py
+++ b/isetL3/data/l3_data_s.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Any
+
+
+class L3DataS(ABC):
+    """Base class for L3 data generation."""
+
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+        self.in_img: List[Any] = []
+        self.out_img: List[Any] = []
+
+    @property
+    @abstractmethod
+    def cfa(self) -> Any:
+        """Return the CFA pattern."""
+
+    @property
+    def p_type(self) -> Any:
+        if self.in_img:
+            # Assume first image defines shape
+            import numpy as np
+            return np.zeros_like(self.in_img[0], dtype=int)
+        return None
+
+    @abstractmethod
+    def data_get(
+        self, n_img: int = 1, *args: Any, **kwargs: Any
+    ) -> Tuple[List[Any], List[Any], Any]:
+        """Return input and output image pairs."""

--- a/isetL3/data/l3_data_simulation.py
+++ b/isetL3/data/l3_data_simulation.py
@@ -1,0 +1,32 @@
+from typing import List, Any, Tuple
+
+from .l3_data_s import L3DataS
+
+
+class L3DataSimulation(L3DataS):
+    """Placeholder for ISET camera simulation data."""
+
+    def __init__(
+        self,
+        camera: Any = None,
+        sources: List[Any] | None = None,
+        name: str = "default",
+    ) -> None:
+        super().__init__(name)
+        self.camera = camera
+        self.sources = sources or []
+        self.exp_frac = [1, 0.6, 0.3, 0.1]
+        self.ideal_cmf: Any = None
+        self.verbose = True
+
+    @property
+    def cfa(self) -> Any:
+        if self.camera is not None:
+            return getattr(self.camera, "cfa", None)
+        return None
+
+    def data_get(
+        self, n_img: int = 1, *args: Any, **kwargs: Any
+    ) -> Tuple[List[Any], List[Any], Any]:
+        # Placeholder: this should run an image simulation
+        return [], [], self.cfa

--- a/isetL3/l3rootpath.py
+++ b/isetL3/l3rootpath.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def l3_root_path() -> Path:
+    """Return the path to the repository root directory."""
+    return Path(__file__).resolve().parent.parent

--- a/isetL3/render/__init__.py
+++ b/isetL3/render/__init__.py
@@ -1,0 +1,5 @@
+"""Rendering utilities for L3."""
+
+from .l3_render import L3Render
+
+__all__ = ["L3Render"]

--- a/isetL3/render/l3_render.py
+++ b/isetL3/render/l3_render.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+
+class L3Render:
+    """Simple renderer applying learned kernels."""
+
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+
+    def render(
+        self,
+        raw_data: Any,
+        p_type: Any,
+        l3t: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        from ..data import L3DataCamera
+
+        l3c = l3t.l3c
+        data_obj = L3DataCamera([raw_data], [raw_data], p_type)
+        l3c.classify(data_obj, *args, **kwargs)
+        labels = l3c.labels[0]
+        kernels = l3t.kernels
+        import numpy as np
+        out = np.zeros_like(raw_data, dtype=float)
+        for idx, kernel in enumerate(kernels):
+            if kernel is None:
+                continue
+            mask = labels == idx
+            X = raw_data[mask]
+            X = np.expand_dims(X, axis=1)
+            X = np.pad(X, ((0, 0), (1, 0)), constant_values=1)
+            out[mask] = X @ kernel
+        return out

--- a/isetL3/train/__init__.py
+++ b/isetL3/train/__init__.py
@@ -1,0 +1,6 @@
+"""Training utilities for L3."""
+
+from .l3_train_s import L3TrainS
+from .l3_train_ols import L3TrainOLS
+
+__all__ = ["L3TrainS", "L3TrainOLS"]

--- a/isetL3/train/l3_train_ols.py
+++ b/isetL3/train/l3_train_ols.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from ..classify import L3ClassifyS
+from .l3_train_s import L3TrainS
+
+
+class L3TrainOLS(L3TrainS):
+    """Ordinary least squares training implementation."""
+
+    def __init__(
+        self,
+        l3c: L3ClassifyS | None = None,
+        name: str = "l3 Train OLS instance",
+        p_min: int = 50,
+        verbose: bool = True,
+    ) -> None:
+        super().__init__(name=name, l3c=l3c)
+        self.p_min = p_min
+        self.verbose = verbose
+        self.out_channel_names = ["red", "green", "blue"]
+
+    def train(
+        self, l3d: Any, *args: Any, **kwargs: Any
+    ) -> "L3TrainOLS":
+        l3c = self.l3c
+        if l3c is None:
+            raise ValueError("l3c must be set")
+        l3c.classify(l3d, *args, **kwargs)
+        n_labels = getattr(l3c, "n_labels", 0)
+        self.kernels = [None] * n_labels
+        for idx in range(n_labels):
+            X, y = l3c.get_class_data(idx)
+            if X is None or y is None or len(X) < self.p_min:
+                continue
+            X = np.pad(X, ((0, 0), (1, 0)), constant_values=1)
+            beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+            self.kernels[idx] = beta
+        return self

--- a/isetL3/train/l3_train_s.py
+++ b/isetL3/train/l3_train_s.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, List
+
+from ..classify import L3ClassifyS
+
+
+class L3TrainS(ABC):
+    """Base class for L3 training."""
+
+    def __init__(self, name: str = "", l3c: L3ClassifyS | None = None) -> None:
+        self.name = name
+        self.l3c = l3c
+        self.kernels: List[Any] | None = None
+        self.out_channel_names: List[str] | None = None
+
+    @property
+    def n_channel_out(self) -> int:
+        if self.kernels:
+            import numpy as np
+            return np.asarray(self.kernels[0]).shape[1]
+        elif self.l3c:
+            return getattr(self.l3c, "n_channel_out", 0)
+        return 0
+
+    @abstractmethod
+    def train(self, l3d: Any, *args: Any, **kwargs: Any) -> "L3TrainS":
+        """Train kernels for each class."""
+
+    def save(self, fname: str, keep_data: bool = False) -> None:
+        import pickle
+        if not keep_data and self.l3c is not None:
+            self.l3c.clear_data()
+        with open(fname, "wb") as f:
+            pickle.dump(self, f)
+
+    @classmethod
+    def load(cls, fname: str) -> "L3TrainS":
+        import pickle
+        with open(fname, "rb") as f:
+            return pickle.load(f)


### PR DESCRIPTION
## Summary
- expand Python port with data classes, a simple classifier, and OLS training
- add minimal renderer
- expose new modules in package init files and update l3_root_path
- document Python usage and provide `example_python_usage.py`

## Testing
- `flake8 isetL3 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6865da817d288331ac098d167c1c7d88